### PR TITLE
Added label to seen_segments, validation overlapping threshold

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -239,6 +239,13 @@ if __name__ == "__main__":
                                       "for the confidence and it has to be defined in the parser.",
                                  type=int,
                                  default=None)
+    
+    validate_parser.add_argument("-ot", "--overlapping-threshold",
+                                 dest="overlapping_threshold_s",
+                                 help="Overlap threshold in seconds between two segments to consider them (correctly) classified."\
+                                      "(default = 0.5).",
+                                 type=float,
+                                 default=.5)
 
     
     args, custom_args = arg_parser.parse_known_args()
@@ -335,6 +342,7 @@ if __name__ == "__main__":
                     positive_labels = positive_labels,
                     late_start = args.late_start,
                     early_stop = args.early_stop,
+                    overlapping_threshold_s = args.overlapping_threshold_s
                 )
 
                 for s in [stime, scount]:
@@ -354,7 +362,8 @@ if __name__ == "__main__":
                 binary = args.binary,
                 positive_labels = positive_labels,
                 late_start = args.late_start,
-                early_stop = args.early_stop
+                early_stop = args.early_stop,
+                overlapping_threshold_s = args.overlapping_threshold_s
             )
 
         def save_stats(stats: tuple[pd.DataFrame, pd.DataFrame], suffix: str):

--- a/parsers.py
+++ b/parsers.py
@@ -95,7 +95,7 @@ class RavenParser(TableParser):
                 self.set_coli(theader)
             for row in csvr:
                 segment = self.get_segment(row)
-                if (next_segment := (segment.tstart, segment.tend)) not in seen_segments:
+                if (next_segment := (segment.tstart, segment.tend, segment.label)) not in seen_segments:
                     yield segment
                     seen_segments.add(next_segment)
 


### PR DESCRIPTION
Added label to seen_segments so that we can have two overlapping segments with different labels (using Raven parser)s
Added a validation overlapping threshold. The confusion matrix count gets updated iff there is at least some overlapping between the two compared segments (validation and ground truth).