### PR TITLE
Merge plaf: procedure splitted into multiple functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 
 *.csv
 *.tflite
+*.ipynb

--- a/__main__.py
+++ b/__main__.py
@@ -259,6 +259,14 @@ if __name__ == "__main__":
                                       "(default = 0.5).",
                                  type=float,
                                  default=.5)
+    
+    validate_parser.add_argument("-smgt", "--skip-missing-gt",
+                                 dest="skip_missing_gt",
+                                 help="Whether to skip the missing ground-truth file or consider them as noise."\
+                                      "(default = True).",
+                                type=bool,
+                                action=BooleanOptionalAction,
+                                default=True)
 
     
     args, custom_args = arg_parser.parse_known_args()
@@ -357,7 +365,8 @@ if __name__ == "__main__":
                     positive_labels = positive_labels,
                     late_start = args.late_start,
                     early_stop = args.early_stop,
-                    overlapping_threshold_s = args.overlapping_threshold_s
+                    overlapping_threshold_s = args.overlapping_threshold_s,
+                    skip_missing_gt=args.skip_missing_gt
                 )
 
                 for s in [stime, scount]:
@@ -378,7 +387,8 @@ if __name__ == "__main__":
                 positive_labels = positive_labels,
                 late_start = args.late_start,
                 early_stop = args.early_stop,
-                overlapping_threshold_s = args.overlapping_threshold_s
+                overlapping_threshold_s = args.overlapping_threshold_s,
+                skip_missing_gt=args.skip_missing_gt
             )
 
         def save_stats(stats: tuple[pd.DataFrame, pd.DataFrame], suffix: str):

--- a/annotations.py
+++ b/annotations.py
@@ -183,7 +183,7 @@ class Annotations:
                 
             if not stats_only:
                 af_wrap.audio_file.export_all_birdnet(export_dir, af_wrap.segments, proc_logger=proc_logger, logger=logger, progress_bar=prog_bar, **kwargs)
-        
+            prog_bar.print(1)
         calculate_and_save_stats(stats, stats_pad, export_dir)
         prog_bar.terminate()
 

--- a/annotations.py
+++ b/annotations.py
@@ -63,6 +63,7 @@ class Annotations:
         self.tables_dir = tables_dir
         self.recursive_subfolders = recursive_subfolders
         self.tables_paths: list = []
+        self.audio_files: None | dict[str, SegmentsWrapper] = None
 
         if recursive_subfolders:
             for dirpath, dirs, files in os.walk(self.tables_dir):
@@ -78,17 +79,20 @@ class Annotations:
         if len(self.tables_paths) == 0:
             raise AttributeError("No annotations found in the provided folder.")
 
-    def load(self, logger: Logger = None, list_rel_paths: list[str] = None, **kwargs):
+    def load(self, logger: Logger = Logger(log=False), list_rel_paths: list[str] = None, **kwargs):
 
         self.audio_files: dict[str, SegmentsWrapper] = dict()
         prog_bar = ProgressBar("Reading tables", len(self.tables_paths))
 
         for table_path in self.tables_paths:
+            if self.parser.table_per_file\
+               and list_rel_paths is not None\
+               and self.parser.get_audio_rel_no_ext_path(table_path, self.tables_dir) not in list_rel_paths:
+                continue
             for rel_path, segment in zip(self.parser.get_audio_rel_no_ext_paths(table_path, self.tables_dir), 
                                          self.parser.get_segments(table_path)):
                 if list_rel_paths is not None and rel_path not in list_rel_paths:
-                    prog_bar.print(1)
-                    continue
+                    break
                 basename = os.path.basename(rel_path)
                 if rel_path in self.audio_files.keys():
                     self.audio_files[rel_path].segments.append(segment)
@@ -103,13 +107,21 @@ class Annotations:
                         unique=False
                         break
                 self.audio_files.setdefault(rel_path, SegmentsWrapper(unique)).segments.append(segment)
-                prog_bar.print(1)
+            prog_bar.print(1)
                 
         for v in self.audio_files.values():
             v.segments = sorted(v.segments, key=lambda seg: seg.tstart)
         prog_bar.terminate()
 
-
+    def map_labels(self, label_settings_path=None, **kwargs):
+        if label_settings_path is not None and os.path.isfile(label_settings_path):
+            prog_bar = ProgressBar("Changing labels", self.n_segments)
+            label_mapper = LabelMapper(label_settings_path)
+            for af_wrap in self.audio_files.values():
+                for seg in af_wrap.segments:
+                    seg.label = label_mapper.map(seg.label)
+                    prog_bar.print(1)
+            prog_bar.terminate()
 
     @property
     def n_tables(self):
@@ -128,6 +140,7 @@ class Annotations:
         logger.print("Output audio folder:", export_dir)
 
         self.load(logger, **kwargs)
+        self.map_labels(**kwargs)
 
         if not stats_only:
             prog_bar = ProgressBar("Retrieving audio paths", self.n_segments)
@@ -162,15 +175,6 @@ class Annotations:
             prog_bar.terminate()
 
 
-        if "label_settings_path" in kwargs and os.path.isfile(kwargs["label_settings_path"]):
-            prog_bar = ProgressBar("Changing labels", self.n_segments)
-            label_mapper = LabelMapper(**kwargs)
-            for af_wrap in self.audio_files.values():
-                for seg in af_wrap.segments:
-                    seg.label = label_mapper.map(seg.label)
-                    prog_bar.print(1)
-            prog_bar.terminate()
-
         prog_bar = ProgressBar("Generating statistics" if stats_only else "Exporting segments", self.n_segments)
         proc_logger = ProcLogger(**kwargs)
         logger.print("Found", len(self.audio_files), "audio files.")
@@ -198,7 +202,10 @@ class Annotations:
         Returns an `Annotation` deepcopy object where all segments below the
         confidence threshold are removed.
         """
+
         copy = deepcopy(self)
+        if self.audio_files is None:
+            self.load()
         for rel_path in copy.audio_files.keys():
             segs = copy.audio_files[rel_path].segments
             copy.audio_files[rel_path].segments = [s for s in segs if s.confidence >= confidence_threshold]
@@ -214,12 +221,14 @@ class Annotations:
 def validate(
         ground_truth: Annotations,
         to_validate: Annotations,
+        filter_confidence: float = None,
         binary=False,
         positive_labels: str=None,
         overlapping_threshold_s: float = .5,
         late_start = False,
         early_stop = False,
         skip_missing_gt = True,
+        **kwargs
         ):
     """
     Compare the annotations to validate to the ground truth ones.
@@ -238,15 +247,23 @@ def validate(
     """
 
     ground_truth.load()
+    if "gt_label_settings_path" in kwargs:
+        ground_truth.map_labels(kwargs["gt_label_settings_path"])
+
 
     # Only load the tables that we want to validate (saves time)
     if skip_missing_gt:
         gt_paths = ground_truth.audio_files.keys()
         to_validate.load(list_rel_paths=gt_paths)
+        if filter_confidence is not None:
+            to_validate = to_validate.filter_confidence(filter_confidence)
+
+
 
     all_rel_paths = set(ground_truth.audio_files.keys()) | set(to_validate.audio_files.keys())
     labels: set[str] = set()
     overlapping_threshold = TimeUnit(overlapping_threshold_s)
+
 
 
 
@@ -319,10 +336,9 @@ def validate(
         # If there are no labels in the ground truth, there are only FP
         # Unless skip_missing_gt is True
         if not rel_path in ground_truth.audio_files:
-            if not skip_missing_gt:
-                for seg in af_tv.segments:
-                    if seg.label != NOISE_LABEL:
-                        set_both(NOISE_LABEL, seg.label, seg.dur)
+            for seg in af_tv.segments:
+                if seg.label != NOISE_LABEL:
+                    set_both(NOISE_LABEL, seg.label, seg.dur)
             continue
         
         # If there are no labels in the validation, there are only FN
@@ -424,3 +440,11 @@ def validate(
         return df_matrix, df_metrics
 
     return  stats(conf_time_matrix), stats(conf_count_matrix)
+
+def plot_stats(stats, fout):
+    conf, metrics = stats
+
+
+def plot_both_stats(statss, fouts):
+    for stats, fout in zip(statss, fouts):
+        plot_stats(stats, fout)

--- a/audio_file.py
+++ b/audio_file.py
@@ -51,6 +51,7 @@ class AudioFile:
         self.ext = self.splits[-1].lower()
         self.duration = TimeUnit(sf.info(self.path).duration)
         self.date_time = None
+        self.rel_path = None
     
     def set_date(self, date_format:str = "%Y%m%d_%H%M%S", **kwargs):
         """

--- a/generic_parser.py
+++ b/generic_parser.py
@@ -48,6 +48,7 @@ class TableParser:
     segment_type: Segment
     header: bool = True
     table_fnmatch: str = "*.csv"
+    table_per_file: bool = True
 
     def __post_init__(self):
         # `self.columns` lists the columns used for retrieving the segment data (order is relevant!)
@@ -88,10 +89,22 @@ class TableParser:
             for row in csvr:
                 yield self.get_segment(row)
 
+    def get_audio_rel_no_ext_path(self, table_path: str, tables_base_path: str):
+        table_basename = os.path.basename(table_path)
+        table_subpath = os.path.dirname(table_path)
+        if table_subpath.startswith(tables_base_path):
+            table_subpath = table_subpath[len(tables_base_path):]
+        
+        while table_subpath.startswith(os.sep):
+            table_subpath = table_subpath[1:]
+        audio_rel_no_ext_paths = os.path.join(table_subpath, table_basename.split(".")[0])
+        
+        return audio_rel_no_ext_paths
+
     def get_audio_rel_no_ext_paths(self, table_path: str, tables_base_path: str):
         """
         Given the table path, the directory containing the audio file and the audio file
-        extenstion, returns a generator that yields the path to theaudio file corresponding 
+        extenstion, returns a generator that yields the path to the audio file corresponding 
         to each segment.
         The path is relative to the `tables_base_path` and doesn't contain the audio file 
         extension. 
@@ -102,11 +115,7 @@ class TableParser:
         by looking in the audio directory for audio files that have the same 
         name as the table + the provided extension in the arguments.
         """
-        table_basename = os.path.basename(table_path)
-        table_subpath = os.path.dirname(table_path)[len(tables_base_path):]
-        while table_subpath.startswith(os.sep):
-            table_subpath = table_subpath[1:]
-        audio_rel_no_ext_paths = os.path.join(table_subpath, table_basename.split(".")[0])
+        audio_rel_no_ext_paths = self.get_audio_rel_no_ext_path(table_path, tables_base_path)
         with open(table_path, encoding='utf-8') as fp:
             csvr = csv.reader(fp, delimiter=self.delimiter)
             for _ in csvr:

--- a/generic_parser.py
+++ b/generic_parser.py
@@ -92,13 +92,12 @@ class TableParser:
     def get_audio_rel_no_ext_path(self, table_path: str, tables_base_path: str):
         table_basename = os.path.basename(table_path)
         table_subpath = os.path.dirname(table_path)
-        if table_subpath.startswith(tables_base_path):
-            table_subpath = table_subpath[len(tables_base_path):]
+        table_subpath = table_subpath[len(tables_base_path):]
         
         while table_subpath.startswith(os.sep):
             table_subpath = table_subpath[1:]
         audio_rel_no_ext_paths = os.path.join(table_subpath, table_basename.split(".")[0])
-        
+
         return audio_rel_no_ext_paths
 
     def get_audio_rel_no_ext_paths(self, table_path: str, tables_base_path: str):

--- a/loggers.py
+++ b/loggers.py
@@ -13,6 +13,7 @@ class ProgressBar():
         self.amount = 0
         self.increment=total/100
         self.text = text
+        self.terminated = False
         self.print(increment=0)
 
     def is_to_update(self, i, verbose):
@@ -20,25 +21,30 @@ class ProgressBar():
                 return verbose and not i%self.increment
     
     def print(self, increment=None):
-                if increment is None:
-                    increment = self.increment
-                self.amount+=increment
-                if self.amount > self.total:
-                    self.amount = self.total
+        if self.terminated:
+            return
+        if increment is None:
+            increment = self.increment
+        self.amount+=increment
+        if self.amount > self.total:
+            self.amount = self.total
 
-                fraction = self.amount / self.total
+        fraction = self.amount / self.total
 
-                arrow = int(fraction * self.bar_length - 1) * '-' + '>'
-                padding = int(self.bar_length - len(arrow)) * ' '
+        arrow = int(fraction * self.bar_length - 1) * '-' + '>'
+        padding = int(self.bar_length - len(arrow)) * ' '
 
-                ending = '\n' if self.amount == self.total else '\r'
+        ending = '\n' if self.amount == self.total else '\r'
 
-                print(f'{self.text}: [{arrow}{padding}] {int(fraction*100)}%', end=ending)
+        print(f'{self.text}: [{arrow}{padding}] {int(fraction*100)}%', end=ending)
 
     def terminate(self):
+        if self.terminated:
+            return
         rest = self.total - self.amount
         if rest > 0:
             self.print(rest)
+        self.terminated = True
 
 class Logger:
     def __init__(self, logfile=None, logfile_path=None, log=True, log_date=True):

--- a/parsers.py
+++ b/parsers.py
@@ -67,6 +67,7 @@ class AudacityParser(TableParser):
         segment_type = Segment,
         header = False,
         table_fnmatch = "*.txt",
+        table_per_file = True,
         **kwargs
     ):
         super().__init__(**collect_args(locals())) 
@@ -82,6 +83,7 @@ class RavenParser(TableParser):
         label = Column("Annotation", 10),
         table_fnmatch = "*.selections.txt",
         segment_type = Segment,
+        table_per_file = True,
         **kwargs
     ):
         super().__init__(**collect_args(locals())) 
@@ -109,6 +111,7 @@ class KaleidoscopeParser(TableParser):
         label = Column("scientific_name", 5),
         table_fnmatch = "*.csv",
         segment_type = DurSegment,
+        table_per_file = False,
         **kwargs
     ):
         super().__init__(**collect_args(locals()))
@@ -155,6 +158,7 @@ class BirdNetRavenParser(RavenParser):
         label = Column("Species Code", 10),
         table_fnmatch = "*.BirdNET.selection.table.txt",
         segment_type = ConfidenceSegment,
+        table_per_file = True,
         **kwargs
     ):
         super().__init__(**collect_args(locals())) 
@@ -177,6 +181,7 @@ class BirdNetCSVParser(TableParser):
         label = Column("label", 6),
         table_fnmatch = "*.csv",
         segment_type = ConfidenceSegment,
+        table_per_file = True,
         **kwargs
     ):
         super().__init__(**collect_args(locals()))

--- a/segment.py
+++ b/segment.py
@@ -43,13 +43,18 @@ class Segment(it.Interval):
     
     def centered_pad(self, pad: TimeUnit):
         return Segment(self.tstart - pad, self.tend + pad, self.label)
+    
+    def safe_centered_pad(self, pad: TimeUnit):
+        if self.tstart-pad < 0:
+            return Segment(0, self.tend + pad + (pad - self.tstart))
+        return self.centered_pad(pad)
 
     def centered_pad_to(self, duration: TimeUnit):
-        return self.centered_pad((duration - self.dur)/2)
-
-    def birdnet_pad(self):
-        if self.dur > BIRDNET_AUDIO_DURATION:
+        if self.dur > duration:
             return self
+        return self.safe_centered_pad((duration - self.dur)/2)
+    
+    def birdnet_pad(self):
         return self.centered_pad_to(BIRDNET_AUDIO_DURATION)
 
     def overlapping_time(self, other: 'Segment'):


### PR DESCRIPTION
I splitted the procedure inside the `extract_for_training()` and `__init__()` functions to make the single operations more usable and more efficient validation (no need to load *all* annotations).
The validation is performed only on the provided files.